### PR TITLE
golang-jx-quickstart to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: golang-jx-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: results
+  version: 0.0.2


### PR DESCRIPTION
Promote golang-jx-quickstart to version 0.0.2